### PR TITLE
[IMP] resource_stock_information: reset values when back in stock

### DIFF
--- a/resource_planning/models/resource_resource.py
+++ b/resource_planning/models/resource_resource.py
@@ -17,6 +17,7 @@ class ResourceResource(models.Model):
         return location
 
     category_id = fields.Many2one("resource.category", string="Category")
+    # todo is this needed ? couldn't it be dealt w/ active field ?
     state = fields.Selection(
         [
             ("draft", "Draft"),
@@ -68,18 +69,15 @@ class ResourceResource(models.Model):
 
     @api.multi
     def action_unavailable(self):
-        for resource in self:
-            resource.state = "unavailable"
+        self.write({"state": "unavailable"})
 
     @api.multi
     def action_available(self):
-        for resource in self:
-            resource.state = "available"
+        self.write({"state": "available"})
 
     @api.multi
     def action_draft(self):
-        for resource in self:
-            resource.state = "draft"
+        self.write({"state": "draft"})
 
     def check_dates(self, date_start, date_end):
         if not date_start or not date_end:

--- a/resource_stock_information/models/resource_resource.py
+++ b/resource_stock_information/models/resource_resource.py
@@ -10,8 +10,10 @@ class Resource(models.Model):
     purchase_date = fields.Date(string="Purchase Date")
     purchase_invoice_ref = fields.Char(string="Purchase Invoice Ref")
 
-    removed_from_stock = fields.Boolean(string="Removed From Stock", default=False)
-    stock_removal_date = fields.Date(string="Stock Removal Date")
+    removed_from_stock = fields.Boolean(
+        string="Removed From Stock", default=False, track_visibility=True
+    )
+    stock_removal_date = fields.Date(string="Stock Removal Date", track_visibility=True)
     stock_removal_reason = fields.Selection(
         string="Stock Removal Reason",
         selection=[
@@ -21,9 +23,10 @@ class Resource(models.Model):
             ("broken", "Broken"),
             ("other", "Other"),
         ],
+        track_visibility=True,
     )
-    selling_price = fields.Float(string="Selling Price")
-    sale_invoice_ref = fields.Char(string="Sale Invoice Ref")
+    selling_price = fields.Float(string="Selling Price", track_visibility=True)
+    sale_invoice_ref = fields.Char(string="Sale Invoice Ref", track_visibility=True)
 
     @api.multi
     def action_remove_from_stock(self):
@@ -42,3 +45,17 @@ class Resource(models.Model):
             "res_id": wiz.id,
             "target": "new",
         }
+
+    @api.multi
+    def action_available(self):
+        res = super().action_available()
+        self.write(
+            {
+                "removed_from_stock": False,
+                "stock_removal_date": False,
+                "stock_removal_reason": False,
+                "selling_price": False,
+                "sale_invoice_ref": False,
+            }
+        )
+        return res

--- a/resource_stock_information/tests/test_resource_stock_information.py
+++ b/resource_stock_information/tests/test_resource_stock_information.py
@@ -174,3 +174,32 @@ class TestResourceStockInformation(common.TransactionCase):
         )
         wiz.force_remove = True
         wiz.button_remove_resource_from_stock()
+
+    def test_resource_removed_set_available(self):
+        wiz_action = self.bike_1.action_remove_from_stock()
+        wiz = self.env[wiz_action["res_model"]].browse(wiz_action["res_id"])
+        today = Date.today()
+        reason = "sold"
+        selling_price = 3
+        invoice_ref = "REF001"
+
+        wiz.write(
+            {
+                "stock_removal_date": today,
+                "stock_removal_reason": reason,
+                "selling_price": selling_price,
+                "sale_invoice_ref": invoice_ref,
+                "force_remove": True,
+            }
+        )
+        wiz.remove_resource_from_stock()
+        self.assertEquals(self.bike_1.state, "unavailable")
+
+        self.bike_1.action_available()
+
+        self.assertFalse(self.bike_1.removed_from_stock)
+        self.assertEquals(self.bike_1.state, "available")
+        self.assertFalse(self.bike_1.stock_removal_date)
+        self.assertFalse(self.bike_1.stock_removal_reason)
+        self.assertFalse(self.bike_1.selling_price)
+        self.assertFalse(self.bike_1.sale_invoice_ref)


### PR DESCRIPTION
[task](https://gestion.coopiteasy.be/web?#id=7509&view_type=form&model=project.task&action=475&active_id=198)

- reset values when putting a value back to available
- track resource information value chage