### PR TITLE
[12.0][FIX] fix conflict check for cancelled allocations

### DIFF
--- a/resource_planning/models/resource_allocation.py
+++ b/resource_planning/models/resource_allocation.py
@@ -16,6 +16,9 @@ class ResourceAllocation(models.Model):
     @api.constrains("resource_id", "date_start", "date_end", "location")
     def _check_resource_allocations(self):
         for allocation in self:
+            if allocation.state == "cancel":
+                # cancelled allocations never conflict and must thus be ignored.
+                continue
             other_allocations = (
                 self.get_allocations(
                     allocation.date_start,

--- a/resource_planning/readme/newsfragments/28.bugfix.rst
+++ b/resource_planning/readme/newsfragments/28.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure that cancelled resource allocation are ignored when checking for
+allocation conflicts.

--- a/resource_planning/tests/test_resource_planning.py
+++ b/resource_planning/tests/test_resource_planning.py
@@ -171,3 +171,28 @@ class TestResourcePlanning(common.TransactionCase):
 
         with self.assertRaises(ValidationError):
             allocation_2.resource_id = bike_1
+
+    def test_check_resource_allocation_ignore_cancelled(self):
+        """
+        Test that updating the end date of a cancelled allocation does not
+        trigger a conflict error if another non-cancelled allocation exists.
+        """
+        bike_1 = self.env.ref("resource_planning.resource_resource_bike_1_demo")
+        allocation_1 = self.env["resource.allocation"].create(
+            {
+                "resource_id": bike_1.id,
+                "date_start": datetime(2023, 1, 1, 12, 0),
+                "date_end": datetime(2023, 1, 1, 14, 0),
+                "state": "cancel",
+            }
+        )
+        self.env["resource.allocation"].create(
+            {
+                "resource_id": bike_1.id,
+                "date_start": datetime(2023, 1, 1, 12, 0),
+                "date_end": datetime(2023, 1, 1, 14, 0),
+                "state": "booked",
+            }
+        )
+        # this should not raise a ValidationError.
+        allocation_1.date_end = datetime(2023, 1, 1, 13, 0)


### PR DESCRIPTION
## description

ensure that cancelled resource allocations do not check whether they conflict with other ones.

## odoo task

[t10841](https://gestion.coopiteasy.be/web#model=project.task&id=10841)

## Checklist before approval

* [x] tests are present.
* [x] change log snippet is present.